### PR TITLE
Retagged the bitnami images.

### DIFF
--- a/helmcharts/images.yaml
+++ b/helmcharts/images.yaml
@@ -75,7 +75,7 @@ images: &images
 
   postgresql: &postgresql
     registry: "docker.io"
-    repository: "bitnami/postgresql"
+    repository: "sanketikahub/postgresql"
     tag: "17.2.0"
     digest: ""
 
@@ -112,7 +112,7 @@ images: &images
 
   valkey: &valkey
     registry: "docker.io"
-    repository: "bitnami/valkey"
+    repository: "sanketikahub/valkey"
     tag: "8.0.1-debian-12-r3"
     digest: ""
     pullSecrets:
@@ -281,7 +281,7 @@ images: &images
 
   kafka: &kafka
     registry: ""
-    repository: bitnami/kafka
+    repository: sanketikahub/kafka
     tag: 3.6.0
     digest: ""
 
@@ -293,7 +293,7 @@ images: &images
 
   minio: &minio
     registry: docker.io
-    repository: bitnami/minio
+    repository: sanketikahub/minio
     tag: 2024.11.7-debian-12-r0
     digest: ""
 
@@ -334,13 +334,13 @@ images: &images
 
   keycloak: &keycloak
     registry: docker.io
-    repository:  bitnami/keycloak
+    repository:  sanketikahub/keycloak
     tag: "26.0.5-debian-12-r2"
     digest: ""
 
   keycloakConfigCli: &keycloakConfigCli
     registry: docker.io
-    repository: bitnami/keycloak-config-cli
+    repository: sanketikahub/keycloak-config-cli
     tag: 6.2.0-debian-12-r0
 
   hms: &hms
@@ -376,7 +376,7 @@ images: &images
     digest: ""
 
   kubectl: &kubectl
-    repository: "docker.io/bitnami/kubectl"
+    repository: "docker.io/sanketikahub/kubectl"
     tag: "1.26.14-debian-11-r6"
 
   sanketikahub-kubectl: &sanketikahub-kubectl

--- a/helmcharts/obsrv/values.yaml
+++ b/helmcharts/obsrv/values.yaml
@@ -877,7 +877,7 @@ keycloak:
               "secret": "{{ .Values.global.oauth_configs.superset_client_secret }}",
                "redirectUris": [
                       "http{{ if .Values.global.ssl_enabled }}s{{ end }}://{{ .Values.global.domain }}/oauth-authorized/obsrv",
-                      "https://{{ .Values.global.fmps_domain }}/oauth-authorized/obsrv"
+                      "https://superset.{{ .Values.global.fmps_domain }}/oauth-authorized/obsrv"
               ],
               "webOrigins": [
                 "http{{ if .Values.global.ssl_enabled }}s{{ end }}://{{ .Values.global.domain }}"

--- a/helmcharts/services/druid-raw-cluster/charts/zookeeper/values.yaml
+++ b/helmcharts/services/druid-raw-cluster/charts/zookeeper/values.yaml
@@ -74,7 +74,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/zookeeper
+  repository: sanketikahub/zookeeper
   tag: 3.8.0-debian-11-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -649,7 +649,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: sanketikahub/os-shell
     tag: 11-debian-11-r4
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/helmcharts/services/druid-raw-cluster/values.yaml
+++ b/helmcharts/services/druid-raw-cluster/values.yaml
@@ -297,8 +297,8 @@ zookeeper:
   namespace: *druidns
   image:
     registry: docker.io
-    repository: bitnami/zookeeper
-    tag: 3.6-debian-10
+    repository: sanketikahub/zookeeper
+    tag: 3.6
     pullPolicy: IfNotPresent
 
   persistence:

--- a/helmcharts/services/kafka/charts/zookeeper/values.yaml
+++ b/helmcharts/services/kafka/charts/zookeeper/values.yaml
@@ -75,7 +75,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/zookeeper
+  repository: sanketikahub/zookeeper
   tag: 3.8.0-debian-11-r65
   digest: ""
   ## Specify a imagePullPolicy

--- a/helmcharts/services/kafka/values.yaml
+++ b/helmcharts/services/kafka/values.yaml
@@ -70,7 +70,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/kafka
+  repository: sanketikahub/kafka
   tag: 3.3.1-debian-11-r25
   digest: ""
   ## Specify a imagePullPolicy
@@ -770,7 +770,7 @@ externalAccess:
     ##
     image:
       registry: docker.io
-      repository: bitnami/kubectl
+      repository: sanketikahub/kubectl
       tag: 1.25.5-debian-11-r2
       digest: ""
       ## Specify a imagePullPolicy
@@ -1009,7 +1009,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: sanketikahub/os-shell
     tag: 11-debian-11-r63
     digest: ""
     pullPolicy: IfNotPresent
@@ -1089,8 +1089,8 @@ metrics:
     ##
     image:
       registry: docker.io
-      repository: bitnami/kafka-exporter
-      tag: 1.6.0-debian-11-r40
+      repository: sanketikahub/kafka-exporter
+      tag: 1.0.1
       digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -1330,7 +1330,7 @@ metrics:
     ##
     image:
       registry: docker.io
-      repository: bitnami/jmx-exporter
+      repository: sanketikahub/jmx-exporter
       tag: 0.17.2-debian-11-r29
       digest: ""
       ## Specify a imagePullPolicy

--- a/helmcharts/services/keycloak/values.yaml
+++ b/helmcharts/services/keycloak/values.yaml
@@ -102,7 +102,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/keycloak
+  repository: sanketikahub/keycloak
   tag: 26.0.5-debian-12-r2
   digest: ""
   ## Specify a imagePullPolicy
@@ -1112,7 +1112,7 @@ keycloakConfigCli:
   ##
   image:
     registry: docker.io
-    repository: bitnami/keycloak-config-cli
+    repository: sanketikahub/keycloak-config-cli
     tag: 6.2.0-debian-12-r0
     digest: ""
     ## Specify a imagePullPolicy

--- a/helmcharts/services/minio/values.yaml
+++ b/helmcharts/services/minio/values.yaml
@@ -69,7 +69,7 @@ extraDeploy: []
 ##
 image:
   registry: docker.io
-  repository: bitnami/minio
+  repository: sanketikahub/minio
   tag: 2024.11.7-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
@@ -96,7 +96,7 @@ image:
 ##
 clientImage:
   registry: docker.io
-  repository: bitnami/minio-client
+  repository: sanketikahub/minio-client
   tag: 2024.10.29-debian-12-r1
   digest: ""
 ## @param mode MinIO&reg; server mode (`standalone` or `distributed`)
@@ -1115,7 +1115,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
+    repository: sanketikahub/os-shell
     tag: 12-debian-12-r32
     digest: ""
     pullPolicy: IfNotPresent

--- a/helmcharts/services/postgresql/values.yaml
+++ b/helmcharts/services/postgresql/values.yaml
@@ -95,7 +95,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/postgresql
+  repository: sanketikahub/postgresql
   tag: 16.1.0-debian-11-r19
   digest: ""
   ## Specify a imagePullPolicy
@@ -1144,7 +1144,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: sanketikahub/os-shell
     tag: 11-debian-11-r102
     digest: ""
     pullPolicy: IfNotPresent
@@ -1239,7 +1239,7 @@ metrics:
   ##
   image:
     registry: docker.io
-    repository: bitnami/postgres-exporter
+    repository: sanketikahub/postgres-exporter
     tag: 0.12.0-debian-11-r72
     digest: ""
     pullPolicy: IfNotPresent

--- a/helmcharts/services/valkey-dedup/values.yaml
+++ b/helmcharts/services/valkey-dedup/values.yaml
@@ -26,7 +26,7 @@ global:
   ##
   security:
     ## @param global.security.allowInsecureImages Allows skipping image verification
-    allowInsecureImages: false
+    allowInsecureImages: true
   valkey:
     password: ""
   ## Compatibility adaptations for Kubernetes platforms
@@ -106,7 +106,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/valkey
+  repository: sanketikahub/valkey
   tag: 8.0.1-debian-12-r3
   digest: ""
   ## Specify a imagePullPolicy
@@ -1164,7 +1164,7 @@ sentinel:
   ##
   image:
     registry: docker.io
-    repository: bitnami/valkey-sentinel
+    repository: sanketikahub/valkey-sentinel
     tag: 8.0.1-debian-12-r3
     digest: ""
     ## Specify a imagePullPolicy
@@ -1650,7 +1650,7 @@ metrics:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis-exporter
+    repository: sanketikahub/redis-exporter
     tag: 1.66.0-debian-12-r2
     digest: ""
     pullPolicy: IfNotPresent
@@ -2016,7 +2016,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
+    repository: sanketikahub/os-shell
     tag: 12-debian-12-r33
     digest: ""
     pullPolicy: IfNotPresent
@@ -2072,7 +2072,7 @@ kubectl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/kubectl
+    repository: sanketikahub/kubectl
     tag: 1.31.3-debian-12-r0
     digest: ""
     ## Specify a imagePullPolicy

--- a/helmcharts/services/valkey-denorm/values.yaml
+++ b/helmcharts/services/valkey-denorm/values.yaml
@@ -26,7 +26,7 @@ global:
   ##
   security:
     ## @param global.security.allowInsecureImages Allows skipping image verification
-    allowInsecureImages: false
+    allowInsecureImages: true
   valkey:
     password: ""
   ## Compatibility adaptations for Kubernetes platforms
@@ -106,7 +106,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/valkey
+  repository: sanketikahub/valkey
   tag: 8.0.1-debian-12-r3
   digest: ""
   ## Specify a imagePullPolicy
@@ -1164,7 +1164,7 @@ sentinel:
   ##
   image:
     registry: docker.io
-    repository: bitnami/valkey-sentinel
+    repository: sanketikahub/valkey-sentinel
     tag: 8.0.1-debian-12-r3
     digest: ""
     ## Specify a imagePullPolicy
@@ -1650,7 +1650,7 @@ metrics:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis-exporter
+    repository: sanketikahub/redis-exporter
     tag: 1.66.0-debian-12-r2
     digest: ""
     pullPolicy: IfNotPresent
@@ -2016,7 +2016,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
+    repository: sanketikahub/os-shell
     tag: 12-debian-12-r33
     digest: ""
     pullPolicy: IfNotPresent
@@ -2072,7 +2072,7 @@ kubectl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/kubectl
+    repository: sanketikahub/kubectl
     tag: 1.31.3-debian-12-r0
     digest: ""
     ## Specify a imagePullPolicy

--- a/helmcharts/services/velero/values.yaml
+++ b/helmcharts/services/velero/values.yaml
@@ -286,7 +286,7 @@ metrics:
 
 kubectl:
   image:
-    repository: docker.io/bitnami/kubectl
+    repository: docker.io/sanketikahub/kubectl
     # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:


### PR DESCRIPTION
Retagged the bitnami image tags to sanketikahub image tags.
Updated the superset redirect uri.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Migrated container images from Bitnami to SanketikaHub across core services (PostgreSQL, Valkey, Kafka, MinIO, Keycloak, ZooKeeper, Velero) and exporters; minor tag updates included.
- Configuration
  - Updated Superset’s Keycloak redirect URI to use the superset subdomain for OAuth callback.
  - Enabled allowing insecure images for Valkey deployments (dedup and denorm) to support the new image sources.
- Reliability
  - Standardized auxiliary images (kubectl, os-shell, volume-permissions, exporters) to SanketikaHub equivalents for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->